### PR TITLE
Add try_own success test

### DIFF
--- a/test/test_mutexed.cpp
+++ b/test/test_mutexed.cpp
@@ -16,3 +16,10 @@ TEST(BorrowingTest, raii_returning) {
     {mutexed::Owned<int> Owned = i.own();}
     EXPECT_EQ(*i.own(), 4);
 }
+
+TEST(BorrowingTest, try_own_success) {
+    mutexed::Mutexed<int> resource(4);
+    std::optional<mutexed::Owned<int>> maybe_owned = resource.try_own();
+    ASSERT_TRUE(maybe_owned.has_value());
+    EXPECT_EQ(**maybe_owned, 4);
+}


### PR DESCRIPTION
## Summary
- extend mutexed tests with try_own_success case

## Testing
- `cmake .. -DBUILD_TESTS=ON`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685345947e9c832c87a9cb0f67c380fd